### PR TITLE
Fix: Delete 'cr' [prettier/prettier] on fresh start.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Problem:
When I use this template as a starter, after `npm install`, it will show
```
Delete `␍`eslint(prettier/prettier) 
```
on the .ts files.

![delete-cr-error](https://user-images.githubusercontent.com/80441177/143524342-420ef160-ef6b-4724-aaf7-452a08ec8bff.jpg)

It was on Windows 10, with VS Code. Plus the Prettier addon.

## Solution:
I added `"endOfLine": "auto"` to the `.prettierrc` file.

Hope this helps!