### PR TITLE
add role guard and decorator

### DIFF
--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Role } from '@prisma/client';
+import { PrismaService } from 'nestjs-prisma';
+import { ROLES_KEY } from 'src/common/decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private prisma: PrismaService, private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const gqlContext = GqlExecutionContext.create(context);
+    const req = gqlContext.getContext().req;
+    const user = req.user;
+    if (user) {
+      return requiredRoles.includes(user.role);
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '@prisma/client';
+
+export const ROLES_KEY = 'roles';
+
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -8,8 +8,11 @@ import {
   ResolveField,
 } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
+import { Role } from '@prisma/client';
 import { UserEntity } from 'src/common/decorators/user.decorator';
 import { GqlAuthGuard } from 'src/auth/gql-auth.guard';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { Roles } from 'src/common/decorators/roles.decorator';
 import { UsersService } from './users.service';
 import { User } from './models/user.model';
 import { ChangePasswordInput } from './dto/change-password.input';
@@ -28,7 +31,8 @@ export class UsersResolver {
     return user;
   }
 
-  @UseGuards(GqlAuthGuard)
+  @Roles(Role.USER, Role.ADMIN)
+  @UseGuards(GqlAuthGuard, RolesGuard)
   @Mutation(() => User)
   async updateUser(
     @UserEntity() user: User,


### PR DESCRIPTION
Add RolesGuard guard and and Roles decorator to support Role-Based Access Control.

This is an example for users with role USER or ADMIN can call updateUser().

```typescript

@Resolver(() => User)
@UseGuards(GqlAuthGuard)
export class UsersResolver {

  // ...


  @Roles(Role.USER, Role.ADMIN)
  @UseGuards(GqlAuthGuard, RolesGuard)
  @Mutation(() => User)
  async updateUser(
    @UserEntity() user: User,
    @Args('data') newUserData: UpdateUserInput
  ) {
    return this.usersService.updateUser(user.id, newUserData);
  }

  // ...
}

```
