### PR TITLE
refactor: add WORKDIR to Runner image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN npm run build
 
 FROM node:16
 
+WORKDIR /app
+
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Description

Added WORKDIR to the runner image to place build artifacts in the app directory instead of root dir.

## Current behavior

Build artifacts were scattered in the root directory.

```bash
$ docker compose exec nest-api bash
root@e7a9f2f4ad78:/# ls
bin   dev   etc   lib    mnt           opt                package.json  root  sbin  srv  tmp  var
boot  dist  home  media  node_modules  package-lock.json  proc          run   src   sys  usr
```

## New behavior

```bash
$ docker compose exec nest-api bash
root@ac5f46da764e:/app# ls
dist  node_modules  package-lock.json  package.json  src
root@ac5f46da764e:/app# ls /
app  bin  boot  dev  etc  home  lib  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
```
