### PR TITLE
refactor: surround ports with single quotes

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -5,7 +5,7 @@ services:
     container_name: postgres
     restart: always
     ports:
-      - 5432:5432
+      - '5432:5432'
     env_file:
       - .env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - 3000:3000
+      - '3000:3000'
     depends_on:
       - postgres
     env_file:
@@ -17,7 +17,7 @@ services:
     container_name: postgres
     restart: always
     ports:
-      - 5432:5432
+      - '5432:5432'
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Description

Surround ports with single quotes in docker-compose.yml because it is recommended that values containing colons be treated as strings in yaml.

## Additional Information

https://docs.docker.com/compose/compose-file/#ports

> HOST:CONTAINER SHOULD always be specified as a (quoted) string, to avoid conflicts with [yaml base-60 float](https://yaml.org/type/float.html).
