### PR TITLE
fix: use `undefined` as default value of order posts.resolver.ts

### DIFF
--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -71,7 +71,7 @@ export class PostsResolver {
             published: true,
             title: { contains: query || '' },
           },
-          orderBy: orderBy ? { [orderBy.field]: orderBy.direction } : null,
+          orderBy: orderBy ? { [orderBy.field]: orderBy.direction } : undefined,
           ...args,
         }),
       () =>


### PR DESCRIPTION
Query:
```graphql
query {
  publishedPosts(first: 10) {
    edges {
      node {
        id
        title
        content
        author {
          id
          email
          firstname
          lastname
        }
      }
    }
  }
}
```

Response:

```json
{
  "errors": [
    {
      "message": "\nInvalid `prisma.post.findMany()` invocation:\n\n{\n  include: {\n    author: true\n  },\n  where: {\n    published: true,\n    title: {\n      contains: ''\n    }\n  },\n  orderBy: null,\n           ~~~~\n  cursor: undefined,\n  take: 11,\n  skip: undefined\n}\n\nArgument orderBy must not be null. Please use undefined instead.\n\n",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "publishedPosts"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "stacktrace": [
          "Error: ",
          "Invalid `prisma.post.findMany()` invocation:",
          "",
          "{",
          "  include: {",
          "    author: true",
          "  },",
          "  where: {",
          "    published: true,",
          "    title: {",
          "      contains: ''",
          "    }",
          "  },",
          "  orderBy: null,",
          "           ~~~~",
          "  cursor: undefined,",
          "  take: 11,",
          "  skip: undefined",
          "}",
          "",
          "Argument orderBy must not be null. Please use undefined instead.",
          "..."]
      }
    }
  ],
  "data": null
}
```

Argument orderBy must not be null. Please use undefined instead.