### PR TITLE
fix: cursor connection issue with `orderBy`

### DIFF
--- a/src/posts/posts.resolver.ts
+++ b/src/posts/posts.resolver.ts
@@ -71,7 +71,14 @@ export class PostsResolver {
             published: true,
             title: { contains: query || '' },
           },
-          orderBy: orderBy ? { [orderBy.field]: orderBy.direction } : undefined,
+          orderBy: orderBy
+            ? [
+                { [orderBy.field]: orderBy.direction },
+                {
+                  id: 'desc',
+                },
+              ]
+            : undefined,
           ...args,
         }),
       () =>


### PR DESCRIPTION
### Description
The issue occurred when using the `orderBy` argument in the `publishedPosts` query. If an `orderBy` field was specified (other than `id`), and a cursor-based pagination was used with `first` and `after` parameters, the cursor connection could become broken. This resulted in inaccurate pagination results

### Solution
- Include an additional ordering by `id` in the Prisma query by appending `{ id: 'desc' }` as a secondary order in the `orderBy` array.

#### _Note_ 
_This may need to be adapted based on your specific implementation and requirements._